### PR TITLE
Send UTF-8 encoded email, and properly base64-ify subject line. Bug 610706.

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -203,7 +203,13 @@ if (ENABLE_DB) {
 }
 
 if (ENABLE_MAIL) {
-  $mail_result = mail(implode(", ", $notified_people), $subject, $body, "From: ". $from);
+  $mail_headers = array(
+    'From: ' . $from,
+    'Content-Type: text/plain;charset=utf-8'
+  );
+  $enc_subject = "=?utf-8?b?" . base64_encode($subject) . "?=";
+
+  $mail_result = mail(implode(", ", $notified_people), $enc_subject, $body, implode("\r\n", $mail_headers));
 } elseif (DEBUG_ON) {
   $mail_result = FALSE;
   fb("To: ". implode(", ", $notified_people));


### PR DESCRIPTION
Courtesy of http://stackoverflow.com/a/7267426

r? @lauraxt
