### PR TITLE
make the subject contain all of the key information

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -46,8 +46,8 @@ $from = "submitter";
 
 # The following template variables are available:
 # %id%, %notifier%, %editor%, %hours%, %start%, %end%, %details%
-$subject = "PTO notification from %notifier%";
-$edit_subject = "Edit of PTO by %editor%";
+$subject = "PTO: %notifier%";
+$edit_subject = "PTO Edit: %editor%";
 $body = <<<EOD
 %notifier% has submitted %hours% hours of PTO from %start% to %end% with the details:
 %details%

--- a/submit.php
+++ b/submit.php
@@ -167,6 +167,9 @@ if ($is_editing) {
   $subject = $edit_subject;
   $body = $single_day_fix ? $edit_single_day_body : $edit_body;
 }
+
+$subject += $single_day_fix ? " (%start%)" : " (%start% - %end%)";
+
 foreach ($tokens as $token => $replacement) {
   $subject = str_replace($token, $replacement, $subject);
   $body = str_replace($token, $replacement, $body);


### PR DESCRIPTION
Pretty simple, gives relevant info without needing to open the email.

Current behaviour:

PTO Notification from Mike Connor

Desired:

PTO: Mike Connor (2015-04-08 - 2015-04-09)