### PR TITLE
[Bug 1398371] Fix intranet links before intranet.m.o goes away

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -22,6 +22,6 @@
         "mentored": "https://bugzilla.mozilla.org/buglist.cgi?resolution=---&component=PTO&product=Webtools&f1=bug_mentor&o1=isnotempty"
     },
     "urls": {
-        "prod": "https://intranet.mozilla.org/pto/"
+        "prod": "https://pto.mozilla.org/"
     }
 }

--- a/templates/edit.php
+++ b/templates/edit.php
@@ -4,7 +4,7 @@
 	
     <p>Hello, <?php echo email_to_alias($notifier_email) ?>. 
     <?php echo $is_editing ? 'Edit' : 'Submit' ?> your PTO notification here. 
-    (<a href="https://intranet.mozilla.org/Paid_Time_Off_%28PTO%29">Learn about PTO</a>)</p>
+    (<a href="https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=33100583">Learn about PTO</a>)</p>
 
 	<?php
 		if ($aErrors) {


### PR DESCRIPTION
intranet.mozilla.org is scheduled for decom on September 29th. I'd like to fix up these URLs ahead of that, so we'll be able to shut down intranet as planned. 

