### PR TITLE
Add daily half/full breakdown to payroll email

### DIFF
--- a/submit.php
+++ b/submit.php
@@ -65,6 +65,9 @@ if (((int)$_REQUEST["hours"]) < 4) {
 if (isset($_REQUEST["id"]) && $_REQUEST["id"]) {
 	$is_editing = true;
 	$id = (int)$_REQUEST["id"];
+} else {
+	$is_editing = false;
+	$id = 0;
 }
 
 
@@ -156,6 +159,7 @@ $notified_people = $allowed;
 
 $hours = (float)$_REQUEST["hours"];
 $hours_daily = isset($_REQUEST['hours_daily']) && $_REQUEST['hours_daily'] ? urldecode($_REQUEST['hours_daily']) : '{}';
+$day_names = isset($_REQUEST['days']) && $_REQUEST['days'] ? json_decode(urldecode($_REQUEST['days'])) : '{}';
 # $start_time = isset($_REQUEST["start_time"]) ? $_REQUEST["start_time"] : "00:00 am";
 # $end_time = isset($_REQUEST["end_time"]) ? $_REQUEST["end_time"] : "00:00 am";
 $start = maketime($_REQUEST["start"]);
@@ -184,6 +188,14 @@ if ($start == $end) {
   $body = $single_day_body;
   // Expand single day to a timerange of a whole day.
   $end += (1 * 60 * 60 * 24) - 1;
+} else {
+  $hours_per = "-- Hours per day:\n";
+  foreach (json_decode($hours_daily) as $ts => $hours) {
+    $date = $day_names->$ts;
+    $span = $hours == 8 ? "Full Day" : "Half Day";
+    $hours_per = "$hours_per$date : $span\n";
+  }
+  $tokens["%details%"] = $tokens["%details%"] . "\n\n" . $hours_per;
 }
 if ($is_editing) {
   $subject = $edit_subject;

--- a/templates/edit1.php
+++ b/templates/edit1.php
@@ -5,7 +5,7 @@
 $aErrors = array();
 
 // Input data whitelist
-$step1_vars = array('id', 'start', 'end', 'people', 'cc', 'details', 'hours', 'hours_daily');
+$step1_vars = array('id', 'start', 'end', 'people', 'cc', 'details', 'hours', 'hours_daily', 'days');
 $s1data = array_fill_keys($step1_vars, '');  // Default to '' for all input data
 // Fill only expected fields with request data.
 $s1data = array_merge($s1data, array_intersect_key($_REQUEST, $s1data));
@@ -82,6 +82,7 @@ if ($aErrors) {
 		var _oOutputHours 		= $(oConfig.output_hours);
 		var _oInputHours  		= $(oConfig.input_hours);
 		var _oInputHoursDaily 	= $(oConfig.input_hours_daily);
+		var _oInputDays			= $(oConfig.input_days);
 		var _oThis        		= this;
 		
 		$('#'+oConfig.id).html(_oTable);
@@ -207,7 +208,14 @@ if ($aErrors) {
 					oData[this.name] = parseInt(this.value);
 				}
 			});
-			if (_oInputHoursDaily) { _oInputHoursDaily[0].value = encodeURIComponent($.toJSON(oData)); }
+			if (_oInputHoursDaily) {
+				_oInputHoursDaily[0].value = encodeURIComponent($.toJSON(oData));
+				let oDays = {};
+				for (let ts of Object.keys(oData)) {
+					oDays[ts] = new Date(parseInt(ts)).toDateString();
+				}
+				_oInputDays[0].value = encodeURIComponent($.toJSON(oDays));
+			}
 		}
 		
 		function _getDatesBetween(sDateStart, sDateEnd) {
@@ -249,7 +257,8 @@ if ($aErrors) {
 			end_date 		  : JSON.parse('<?php echo json_encode($s1data['end']) ?>'),
 			output_hours	  : '#date_discriminator_hours',
 			input_hours		  : '#hours',
-			input_hours_daily : '#hours_daily'
+			input_hours_daily : '#hours_daily',
+			input_days		  : '#days'
 		});
 	});
 </script>


### PR DESCRIPTION
Extends the email sent to payroll to include if each day is a full or half day.

It's a little bit more involved than you may expect because the dates are selected client-side using the client's local timezone, while the server has no knowledge of the client's timezone.  I've worked around this by stringifying the date client-side and passing that to PHP.